### PR TITLE
Update documentation, redirect some broken pages

### DIFF
--- a/src/pages/documentation.js
+++ b/src/pages/documentation.js
@@ -37,7 +37,7 @@ class Documentation extends React.Component {
 
 
             <DocumentationTile className={styles.icon} iconType={faAndroid}
-            link="https://github.com/getbouncer/cardscan-android" header={documentation_lang.android[this.state.lang]}>
+            link="https://github.com/getbouncer/cardscan-demo-android" header={documentation_lang.android[this.state.lang]}>
 
             </DocumentationTile>
         </section>

--- a/src/pages/id-scan.js
+++ b/src/pages/id-scan.js
@@ -1,0 +1,17 @@
+import dynamic from "next/dynamic";
+
+// This page is legacy, but google has already indexed it. Redirect to our home page
+function IdScanPage() {}
+
+IdScanPage.getInitialProps = ({ res }) => {
+  if (res) {
+    res.writeHead(301, {
+      Location: '/'
+    });
+    res.end();
+  }
+
+  return {};
+}
+
+export default IdScanPage

--- a/src/pages/new-page.js
+++ b/src/pages/new-page.js
@@ -1,0 +1,17 @@
+import dynamic from "next/dynamic";
+
+// This page is legacy, but google has already indexed it. Redirect to our home page
+function NewPage() {}
+
+NewPage.getInitialProps = ({ res }) => {
+  if (res) {
+    res.writeHead(301, {
+      Location: '/'
+    });
+    res.end();
+  }
+
+  return {};
+}
+
+export default NewPage


### PR DESCRIPTION
We have some google search engine result pages that are now broken (/id-scan and /new-page) Redirect those to our homepage for the time being

Also update android docs to cardscan v2 repo